### PR TITLE
Updates to endpoints for Patch, Put, and Delete

### DIFF
--- a/PlaywrightTestsForJsonplaceholder/EndpointTests.cs
+++ b/PlaywrightTestsForJsonplaceholder/EndpointTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Playwright;
 using NUnit.Framework;
+using System.Text.Json;
 
 namespace PlaywrightTestsForJsonplaceholder
 {
@@ -94,7 +95,64 @@ namespace PlaywrightTestsForJsonplaceholder
             Assert.IsNotNull(body);
 
             var retrieveNewPost = await Request.GetAsync("/posts/101");
+            //The endpoint for creating posts does not actually create the new post, check that the new post doesn't exist
             await Expect(retrieveNewPost).Not.ToBeOKAsync();
+        }
+
+        [Test]
+        public async Task PUT_Existing_Post()
+        {
+            //Put is similar to Patch, but will replace the entire data object (and null fields not present)
+            Dictionary<string, object> updateData = new Dictionary<string, object>();
+            updateData.Add("title", "Updated post title");
+            updateData.Add("body", "This is the updated body");
+            updateData.Add("userId", 1);
+
+            var updatedPost = await Request.PutAsync("/posts/1", new() { DataObject = updateData });
+
+            await Expect(updatedPost).ToBeOKAsync();
+            var updatedBody = await updatedPost.JsonAsync();
+            Assert.IsNotNull(updatedBody);
+
+            var retrieveExistingPost = await Request.GetAsync("/posts/1");
+            var getBody = await retrieveExistingPost.JsonAsync();
+            //The endpoint for updating Posts does not change the post, check that the original post does not match
+            Assert.That(getBody.Value, Is.Not.EqualTo(updatedBody.Value));
+        }
+
+        [Test]
+        public async Task PATCH_Existing_Post()
+        {
+            //Patch is similar to Put, but will only replace certain data
+            Dictionary<string, object> updateData = new Dictionary<string, object>();
+            updateData.Add("title", "Updated post title");
+
+            var updatedPost = await Request.PatchAsync("/posts/1", new() { DataObject = updateData });
+
+            await Expect(updatedPost).ToBeOKAsync();
+            var updatedBody = await updatedPost.JsonAsync();
+            string jsonString = JsonSerializer.Serialize(updatedBody);
+            Assert.IsNotNull(updatedBody);
+            Assert.That(jsonString.Contains("Updated post title"));
+
+            var retrieveExistingPost = await Request.GetAsync("/posts/1");
+            var getBody = await retrieveExistingPost.JsonAsync();
+            //The endpoint for patching Posts does not change the post, check that the original post does not match
+            Assert.That(getBody.Value, Is.Not.EqualTo(updatedBody.Value));
+        }
+
+        [Test]
+        public async Task DELETE_Existing_Post()
+        {
+            var deletedPost = await Request.DeleteAsync("/posts/1");
+
+            await Expect(deletedPost).ToBeOKAsync();
+            var body = await deletedPost.JsonAsync();
+            Assert.IsNotNull(body);
+
+            var retrieveExistingPost = await Request.GetAsync("/posts/1");
+            //The endpoint for deleting posts does not actually delete the new post, check that the deleted post isn't deleted
+            await Expect(retrieveExistingPost).ToBeOKAsync();
         }
 
         [TearDown]

--- a/PlaywrightTestsForJsonplaceholder/EndpointTests.cs
+++ b/PlaywrightTestsForJsonplaceholder/EndpointTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Playwright;
 using NUnit.Framework;
-using System.Text.Json;
 
 namespace PlaywrightTestsForJsonplaceholder
 {
@@ -95,64 +94,7 @@ namespace PlaywrightTestsForJsonplaceholder
             Assert.IsNotNull(body);
 
             var retrieveNewPost = await Request.GetAsync("/posts/101");
-            //The endpoint for creating posts does not actually create the new post, check that the new post doesn't exist
             await Expect(retrieveNewPost).Not.ToBeOKAsync();
-        }
-
-        [Test]
-        public async Task PUT_Existing_Post()
-        {
-            //Put is similar to Patch, but will replace the entire data object (and null fields not present)
-            Dictionary<string, object> updateData = new Dictionary<string, object>();
-            updateData.Add("title", "Updated post title");
-            updateData.Add("body", "This is the updated body");
-            updateData.Add("userId", 1);
-
-            var updatedPost = await Request.PutAsync("/posts/1", new() { DataObject = updateData });
-
-            await Expect(updatedPost).ToBeOKAsync();
-            var updatedBody = await updatedPost.JsonAsync();
-            Assert.IsNotNull(updatedBody);
-
-            var retrieveExistingPost = await Request.GetAsync("/posts/1");
-            var getBody = await retrieveExistingPost.JsonAsync();
-            //The endpoint for updating Posts does not change the post, check that the original post does not match
-            Assert.That(getBody.Value, Is.Not.EqualTo(updatedBody.Value));
-        }
-
-        [Test]
-        public async Task PATCH_Existing_Post()
-        {
-            //Patch is similar to Put, but will only replace certain data
-            Dictionary<string, object> updateData = new Dictionary<string, object>();
-            updateData.Add("title", "Updated post title");
-
-            var updatedPost = await Request.PatchAsync("/posts/1", new() { DataObject = updateData });
-
-            await Expect(updatedPost).ToBeOKAsync();
-            var updatedBody = await updatedPost.JsonAsync();
-            string jsonString = JsonSerializer.Serialize(updatedBody);
-            Assert.IsNotNull(updatedBody);
-            Assert.That(jsonString.Contains("Updated post title"));
-
-            var retrieveExistingPost = await Request.GetAsync("/posts/1");
-            var getBody = await retrieveExistingPost.JsonAsync();
-            //The endpoint for patching Posts does not change the post, check that the original post does not match
-            Assert.That(getBody.Value, Is.Not.EqualTo(updatedBody.Value));
-        }
-
-        [Test]
-        public async Task DELETE_Existing_Post()
-        {
-            var deletedPost = await Request.DeleteAsync("/posts/1");
-
-            await Expect(deletedPost).ToBeOKAsync();
-            var body = await deletedPost.JsonAsync();
-            Assert.IsNotNull(body);
-
-            var retrieveExistingPost = await Request.GetAsync("/posts/1");
-            //The endpoint for deleting posts does not actually delete the new post, check that the deleted post isn't deleted
-            await Expect(retrieveExistingPost).ToBeOKAsync();
         }
 
         [TearDown]


### PR DESCRIPTION
Creating tests for each endpoint and verifying the data updates comes back on the response, while the original item is still intact.